### PR TITLE
DockerHubのリンク先を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ $ docker-compose up
 
 # ビルド済コンテナ
 
-[DockerHub](https://cloud.docker.com/swarm/kamiyaowl/repository/docker/kamiyaowl/splatnet2statink-docker/general)
+[DockerHub](https://hub.docker.com/r/kamiyaowl/splatnet2statink-docker/)


### PR DESCRIPTION
元のリンク先が500になっていたので更新しました👍
